### PR TITLE
RefArch: make RA_stop_signal_called atomic Avoid a data race between …

### DIFF
--- a/lib/RefArch.cpp
+++ b/lib/RefArch.cpp
@@ -34,7 +34,7 @@ namespace RA_filesystem = std::filesystem;
 namespace RA_filesystem = boost::filesystem;
 #endif
 
-bool RefArch::RA_stop_signal_called = false;
+std::atomic<bool> RefArch::RA_stop_signal_called{false};  // 
 
 
 void RefArch::parseConfig()

--- a/lib/RefArch.hpp
+++ b/lib/RefArch.hpp
@@ -251,7 +251,9 @@ public:
     /**
      * @brief Used to shutdown all threads.
      */
-    static bool RA_stop_signal_called;
+    
+    static std::atomic<bool> RA_stop_signal_called; // fix
+
     std::vector<std::thread> RA_rx_vector_thread;
     std::vector<std::thread> RA_tx_vector_thread;
 


### PR DESCRIPTION
## Description

Replace `RA_stop_signal_called` with `std::atomic<bool>` in `RefArch`.

The stop flag is accessed by multiple RX/TX threads and modified by
the signal handler during shutdown. Using an atomic flag avoids a
potential data race while preserving existing behavior.

## Related Issue

N/A

## Which devices/areas does this affect?

* RefArch thread shutdown handling
* Multi-threaded RX/TX operation

## Testing Done

* Built successfully with the modified code.
* Verified normal startup and shutdown behavior.
* Confirmed RX/TX threads terminate correctly when the stop signal is set.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes, and all previous tests pass.
